### PR TITLE
some speed optimization

### DIFF
--- a/models/packet.py
+++ b/models/packet.py
@@ -25,16 +25,16 @@ class Packet:
 
     def pack(self) -> bytes:
         qname_utils = QNameUtils()
-        data = self.headers.pack()
+        data = [self.headers.pack()]
         offset = 12
         for question in self.questions:
             b, offset = question.pack(offset, qname_utils)
-            data += b
+            data.append(b)
         all_resource_records = self.answers + self.authorities + self.additions
         for record in all_resource_records:
             b, offset = record.pack(offset, qname_utils)
-            data += b
-        return data
+            data.append(b)
+        return b''.join(data)
 
     @staticmethod
     def parse(data: bytes) -> 'Packet':

--- a/models/qname.py
+++ b/models/qname.py
@@ -4,8 +4,8 @@ class QNameUtils:
     def __init__(self):
         self.pointers = dict()
 
-    def pack(self, name: str, current_offset: int) -> bytes:
-        data = b''
+    def pack(self, name: str, current_offset: int) -> tuple[bytes, int]:
+        data = []
         current_name = name
         while True:
             save_name = current_name
@@ -15,40 +15,39 @@ class QNameUtils:
                 pointer |= 0xC000
                 pointer = int.to_bytes(pointer, 2, 'big')
                 current_offset += 2
-                data += pointer
+                data.append(pointer)
                 break
             else:
                 new_string = current_name.split('.', 1)
                 length = int.to_bytes(len(new_string[0]), 1, 'big')
-                data += length
+                data.append(length)
                 current_offset += 1
                 for i in new_string[0]:
-                    data += i.encode(encoding='ascii')
+                    data.append(i.encode(encoding='ascii'))
                     current_offset += 1
                 if len(new_string) == 1:
                     self.pointers[save_name] = save_offset
-                    data += b'\x00'
+                    data.append(b'\x00')
                     current_offset += 1
                     break
                 current_name = new_string[1]
             self.pointers[save_name] = save_offset
 
-        return data, current_offset
+        return b''.join(data), current_offset
 
     def parse(self, data: bytes, offset: int) -> tuple[str, int]:
         pointer = offset
         length = 0
         current_length = 0
-        result = ''
+        result = []
         while data[pointer] != 0x00:
             if length == 0 or length == current_length:
                 if length != 0:
-                    result += '.'
+                    result.append('.')
                 if data[pointer] & 0xc0 == 0xc0:
                     compress_pointer = (data[pointer] & 0x3F) + data[pointer + 1]
-                    new_pointer = compress_pointer
-                    add_bytes, _ = self.parse(data, new_pointer)
-                    result += add_bytes
+                    additional_string, _ = self.parse(data, compress_pointer)
+                    result.append(additional_string)
                     pointer += 1
                     break
 
@@ -56,11 +55,11 @@ class QNameUtils:
                 current_length = 0
             else:
                 current_length += 1
-                result += chr(data[pointer])
+                result.append(chr(data[pointer]))
             pointer += 1
 
             if pointer - offset > self.MAX_QNAME_LENGTH:
                 return None, 0
         pointer += 1
 
-        return result, pointer
+        return ''.join(result), pointer

--- a/models/question.py
+++ b/models/question.py
@@ -11,13 +11,13 @@ class Question:
     qclass: int
 
     def pack(self, offset: int, utils: QNameUtils) -> tuple[bytes, int]:
-        data = b''
+        data = []
         name, offset = utils.pack(self.name, offset)
-        data += name
-        data += int.to_bytes(self.qtype, 2, 'big')
-        data += int.to_bytes(self.qclass, 2, 'big')
+        data.append(name)
+        data.append(int.to_bytes(self.qtype, 2, 'big'))
+        data.append(int.to_bytes(self.qclass, 2, 'big'))
 
-        return data, offset + 4
+        return b''.join(data), offset + 4
 
     @staticmethod
     def parse(data: bytes, offset: int, utils: QNameUtils) -> tuple['Question', int]:

--- a/models/rdata/a.py
+++ b/models/rdata/a.py
@@ -8,10 +8,7 @@ class AData:
 
     def pack(self) -> bytes:
         ip = self.ip.split('.')
-        data = b''
-        for i in ip:
-            data += int.to_bytes(int(i), 1, byteorder='big')
-        return data
+        return b''.join(int.to_bytes(int(octet), 1, byteorder='big') for octet in ip)
 
     @staticmethod
     def parse(data: bytes, offset: int) -> tuple['AData', int]:

--- a/models/resource_record.py
+++ b/models/resource_record.py
@@ -18,20 +18,20 @@ class ResourceRecord:
     expired_at: time
 
     def pack(self, offset: int, utils: QNameUtils) -> tuple[bytes, int]:
-        data = b''
+        data = []
         name, offset = utils.pack(self.name, offset)
-        data += name
-        data += int.to_bytes(self.rrtype, 2, 'big')
-        data += int.to_bytes(self.rrclass, 2, 'big')
-        data += int.to_bytes(self.ttl, 4, 'big')
-        data += int.to_bytes(self.rdlength, 2, 'big')
+        data.append(name)
+        data.append(int.to_bytes(self.rrtype, 2, 'big'))
+        data.append(int.to_bytes(self.rrclass, 2, 'big'))
+        data.append(int.to_bytes(self.ttl, 4, 'big'))
+        data.append(int.to_bytes(self.rdlength, 2, 'big'))
         if self.rrtype == 1:
             rdata_bytes = self.rdata.pack()
-            data += rdata_bytes
+            data.append(rdata_bytes)
         else:
-            data += 0x00 * self.rdlength
+            data.append(0x00 * self.rdlength)
             offset += self.rdlength
-        return data, offset + 10 + self.rdlength
+        return b''.join(data), offset + 10 + self.rdlength
 
     @staticmethod
     def parse(data: bytes, offset: int, utils: QNameUtils) -> tuple['ResourceRecord', int]:


### PR DESCRIPTION
Исправил медленную конкатенацию байтовых строк на последовательное добавление частей строки в список. В учебных условиях такой подход тоже прокатит, но если запускать это на 100+ клиентов, то будет тормозить.

Еще рекомендую выделить в отдельный метод обратное преобразование числа в байты нужного формата. Например, utils.ushort_number_to_bytes, utils.ulong_numbers_to_bytes

Хорошее решение. Но падает с таймаутом на ру зоне, на org com net все нормально.
